### PR TITLE
Minor fix in DMX code, only needed for larger # of DMX channels

### DIFF
--- a/Arduino/midi2dmx/dmx.cpp
+++ b/Arduino/midi2dmx/dmx.cpp
@@ -36,7 +36,7 @@ void leds_update()
     state = 2;
     break;
   case 2: // transmit data
-    avail = Serial2.availableForWrite();
+    avail = Serial1.availableForWrite();
     if (avail == 0) return;
     num = CHANNELS - chindex;
     if (num > avail) num = avail;


### PR DESCRIPTION
Opps, this one "Serial2" (as used in the SOAK project) didn't get changed to Serial1.